### PR TITLE
Fix Promise deallocation

### DIFF
--- a/web3swift/Transaction/Classes/EthereumTransaction.swift
+++ b/web3swift/Transaction/Classes/EthereumTransaction.swift
@@ -335,6 +335,7 @@ public struct EthereumTransaction: CustomStringConvertible {
         }
         let pars = JSONRPCparams(params: params)
         request.params = pars
+        request.id = UUID().uuidString
         if !request.isValid {return nil}
         return request
     }


### PR DESCRIPTION
If the request does not have an ID set, the Promise related to this request will deallocate and won't execute