### PR TITLE
Promise deallocation

### DIFF
--- a/web3swift/Web3/Classes/Web3+Methods.swift
+++ b/web3swift/Web3/Classes/Web3+Methods.swift
@@ -72,6 +72,7 @@ public enum JSONRPCmethod: String, Encodable {
 public struct JSONRPCRequestFabric {
     public static func prepareRequest(_ method: JSONRPCmethod, parameters: [Encodable]) -> JSONRPCrequest {
         var request = JSONRPCrequest()
+        request.id = UUID().uuidString
         request.method = method
         let pars = JSONRPCparams(params: parameters)
         request.params = pars


### PR DESCRIPTION
If the request does not have an initial ID the Promise related to this request will be deallocated and will not execute