### PR TITLE
Web3Error public description

### DIFF
--- a/web3swift/Web3/Classes/Web3.swift
+++ b/web3swift/Web3/Classes/Web3.swift
@@ -18,7 +18,7 @@ public enum Web3Error: Error {
     case generalError(err:Error)
     case unknownError
     
-    var description : String {
+    public var description : String {
         switch self {
             
         case .transactionSerializationError:


### PR DESCRIPTION
Outside the local environment error strings display with localizedDescription with little or no information of the current error happening.